### PR TITLE
fix: separated createJwt into helper function for more exhaustive tests

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,78 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const jwt = require('jsonwebtoken')
+const debug = require('debug')('@adobe/aio-lib-core-ims-jwt')
+
+/**
+ * Convert a string value to Json. Returns the original string if it fails.
+ *
+ * @param {string} value the value to attempt conversion to Json
+ */
+function parseJson (value) {
+  try {
+    return JSON.parse(value)
+  } catch (e) {
+    return value
+  }
+}
+
+async function createJwt (ims, clientId, imsOrg, techacct, metaScopes, privateKey, passphrase) {
+  // new mechanism: only JWT properties are in the configuration:
+  // configData: An object providing the properties required for JWT with properties:
+  //     imsOrg:        The IMS Org ID of the customer
+  //     techacct:      The Technical Account field of the integration
+  //     clientId:      The client ID assigned to the integration
+  //     clientSecret:  The secret associated to the client ID
+  //     metaScopes:    Array of IMS meta scope related to APIs integrated with
+  //     secret:        The secret key corresponding to the public key
+  //                    registered with the integration
+
+  // Prepare a short lived JWT token to exchange for an access token
+  const payload = {
+    exp: Math.round(Date.now() / 1000 + 300), // 5 minutes expiry time
+    iss: imsOrg,
+    sub: techacct,
+    aud: ims.getApiUrl('/c/' + clientId)
+  }
+
+  // configure the metascope for the JWT (only one supported for now)
+  metaScopes = parseJson(metaScopes)
+  for (const metaScope of metaScopes) {
+    payload[ims.getApiUrl('/s/' + metaScope)] = true
+  }
+
+  privateKey = parseJson(privateKey)
+  let keyParam = (typeof (privateKey) === 'string') ? privateKey : privateKey.join('\n')
+  if (passphrase) {
+    keyParam = {
+      key: privateKey,
+      passphrase
+    }
+  }
+
+  let jwtToken
+  try {
+    jwtToken = jwt.sign(payload, keyParam, { algorithm: 'RS256' }, null)
+    debug('Signed JWT token: %s', jwtToken)
+    return jwtToken
+  } catch (err) {
+    debug('JWT signing failed: %s', err.message)
+    debug(err.stack)
+    throw new Error('A passphrase is needed for your private-key. Use the --passphrase flag to specify one.')
+  }
+}
+
+module.exports = {
+  parseJson,
+  createJwt
+}

--- a/src/ims-jwt.js
+++ b/src/ims-jwt.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Adobe. All rights reserved.
+Copyright 2020 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -10,8 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const jwt = require('jsonwebtoken')
-const debug = require('debug')('@adobe/aio-lib-core-ims-jwt/login')
+const { createJwt } = require('./helpers')
 
 function configMissingKeys (configData) {
   if (!configData) {
@@ -38,50 +37,6 @@ async function canSupport (configData) {
     return Promise.resolve(true)
   } else {
     return Promise.reject(new Error(`JWT not supported due to some missing properties: ${missingKeys}`))
-  }
-}
-
-async function createJwt (ims, clientId, imsOrg, techacct, metaScopes, privateKey, passphrase) {
-  // new mechanism: only JWT properties are in the configuration:
-  // configData: An object providing the properties required for JWT with properties:
-  //     imsOrg:        The IMS Org ID of the customer
-  //     techacct:      The Technical Account field of the integration
-  //     clientId:      The client ID assigned to the integration
-  //     clientSecret:  The secret associated to the client ID
-  //     metaScopes:    Array of IMS meta scope related to APIs integrated with
-  //     secret:        The secret key corresponding to the public key
-  //                    registered with the integration
-
-  // Prepare a short lived JWT token to exchange for an access token
-  const payload = {
-    exp: Math.round(Date.now() / 1000 + 300), // 5 minutes expiry time
-    iss: imsOrg,
-    sub: techacct,
-    aud: ims.getApiUrl('/c/' + clientId)
-  }
-
-  // configure the metascope for the JWT (only one supported for now)
-  for (const metaScope of metaScopes) {
-    payload[ims.getApiUrl('/s/' + metaScope)] = true
-  }
-
-  let keyParam = (typeof (privateKey) === 'string') ? privateKey : privateKey.join('\n')
-  if (passphrase) {
-    keyParam = {
-      key: privateKey,
-      passphrase
-    }
-  }
-
-  let jwtToken
-  try {
-    jwtToken = jwt.sign(payload, keyParam, { algorithm: 'RS256' }, null)
-    debug('Signed JWT token: %s', jwtToken)
-    return jwtToken
-  } catch (err) {
-    debug('JWT signing failed: %s', err.message)
-    debug(err.stack)
-    throw new Error('A passphrase is needed for your private-key. Use the --passphrase flag to specify one.')
   }
 }
 

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -1,0 +1,89 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const { parseJson, createJwt } = require('../src/helpers')
+const jwt = require('jsonwebtoken')
+
+jest.mock('jsonwebtoken')
+
+const gIms = {
+  exchangeJwtToken: jest.fn(),
+  getApiUrl: jest.fn()
+}
+
+beforeEach(() => {
+  jest.restoreAllMocks()
+})
+
+test('parseJson', () => {
+  const myString = 'some-string'
+  const myArray = ['foo', 'bar']
+  const myObject = { foo: 'bar' }
+
+  expect(parseJson(myString)).toEqual(myString) // string, returns string
+  expect(parseJson(JSON.stringify(myArray))).toEqual(myArray) // string contains array, returns json
+  expect(parseJson(JSON.stringify(myObject))).toEqual(myObject) // string contains object, returns json
+  expect(parseJson(myObject)).toEqual(myObject) // object, returns object
+})
+
+test('createJwt', async () => {
+  const myJwtToken = 'my-jwt'
+  const myAccessToken = 'my-access-token'
+
+  const myConfig = {
+    client_id: 'my-client-id',
+    client_secret: 'my-client-secret',
+    ims_org_id: 'my-ims-org-id',
+    techacct: 'my-tech-acct',
+    meta_scopes: ['my', 'meta', 'scopes'],
+    private_key: ['my', 'private', 'key']
+  }
+
+  const myPassphrase = 'my-passphrase'
+  const privateKeyStringNewlines = 'my\nprivate\nkey'
+  const privateKeyStringifiedJson = '["my", "private", "key"]'
+  const metaScopesStringifiedJson = '["my", "meta", "scopes"]'
+
+  jwt.sign.mockImplementation(() => {
+    return myJwtToken
+  })
+
+  gIms.exchangeJwtToken.mockImplementation((clientId, clientSecret, jwtToken) => {
+    expect(jwtToken).toEqual(myJwtToken)
+    return myAccessToken
+  })
+
+  let jwtObject
+
+  // standard config
+  jwtObject = createJwt(gIms, myConfig.clientId, myConfig.imsOrg, myConfig.techacct, myConfig.meta_scopes, myConfig.private_key)
+  await expect(jwtObject).resolves.toEqual(myJwtToken)
+
+  // standard config with passphrase (for coverage)
+  jwtObject = createJwt(gIms, myConfig.clientId, myConfig.imsOrg, myConfig.techacct, myConfig.meta_scopes, myConfig.private_key, myPassphrase)
+  await expect(jwtObject).resolves.toEqual(myJwtToken)
+
+  // config with private_key as string (embedded newlines)
+  jwtObject = createJwt(gIms, myConfig.clientId, myConfig.imsOrg, myConfig.techacct, myConfig.meta_scopes, privateKeyStringNewlines)
+  await expect(jwtObject).resolves.toEqual(myJwtToken)
+
+  // config with private_key as string (stringified json array), meta_scopes as string (stringified json array)
+  jwtObject = createJwt(gIms, myConfig.clientId, myConfig.imsOrg, myConfig.techacct, metaScopesStringifiedJson, privateKeyStringifiedJson)
+  await expect(jwtObject).resolves.toEqual(myJwtToken)
+
+  // mock jwt.sign throwing an error
+  jwt.sign.mockImplementation(() => {
+    throw new Error('sign error')
+  })
+  jwtObject = createJwt(gIms, myConfig.clientId, myConfig.imsOrg, myConfig.techacct, myConfig.meta_scopes, myConfig.private_key, myConfig.passphrase)
+  await expect(jwtObject).rejects.toEqual(new Error('A passphrase is needed for your private-key. Use the --passphrase flag to specify one.'))
+})

--- a/test/ims-jwt.test.js
+++ b/test/ims-jwt.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Adobe. All rights reserved.
+Copyright 2020 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -11,9 +11,10 @@ governing permissions and limitations under the License.
 */
 
 const plugin = require('../src/ims-jwt')
-const jwt = require('jsonwebtoken')
+const helpers = require('../src/helpers')
 
 jest.mock('jsonwebtoken')
+jest.mock('../src/helpers')
 
 const gIms = {
   exchangeJwtToken: jest.fn(),
@@ -48,37 +49,20 @@ test('imsLogin() interface', async () => {
   const myJwtToken = 'my-jwt'
   const myAccessToken = 'my-access-token'
 
-  const myPrivateKey = 'my-private-key'
-  const myPrivateKeyPassphrase = 'my-private-key-passphrase'
-
-  jwt.sign.mockImplementation(() => {
+  helpers.createJwt.mockImplementation(() => {
     return myJwtToken
   })
 
   gIms.exchangeJwtToken.mockImplementation((clientId, clientSecret, jwtToken) => {
     expect(jwtToken).toEqual(myJwtToken)
-    return 'my-access-token'
+    return myAccessToken
   })
 
   // normal acceptable config
   await expect(plugin.imsLogin(gIms, gConfig)).resolves.toEqual(myAccessToken)
 
-  // normal acceptable config, with passphrase for private key
-  const configWithPrivateKeyPassphrase = Object.assign(gConfig, { passphrase: myPrivateKeyPassphrase })
-  await expect(plugin.imsLogin(gIms, configWithPrivateKeyPassphrase)).resolves.toEqual(myAccessToken)
-
-  // private key as a string array, not a string
-  const configWithPrivateKeyArray = Object.assign(gConfig, { private_key: [myPrivateKey] })
-  await expect(plugin.imsLogin(gIms, configWithPrivateKeyArray)).resolves.toEqual(myAccessToken)
-
   // config missing a property
   const configMissingProperties = Object.assign({}, gConfig)
   delete configMissingProperties.client_id
   await expect(plugin.imsLogin(gIms, configMissingProperties)).rejects.toEqual(new Error('JWT not supported due to some missing properties: client_id'))
-
-  // mock jwt.sign throwing an error
-  jwt.sign.mockImplementation(() => {
-    throw new Error('sign error')
-  })
-  await expect(plugin.imsLogin(gIms, gConfig)).rejects.toEqual(new Error('A passphrase is needed for your private-key. Use the --passphrase flag to specify one.'))
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Support private_key and meta_scope config keys as strings (stringified json arrays).

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
There is a workflow where the config settings are read from .env files. .env files cannot support arrays, but are always read in as strings. This will attempt to convert the string into JSON, but falls back to the input string if it can't be converted.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
