### PR TITLE
Update peer dependency version for @adobe/aio-lib-ims

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "jsonwebtoken": "^9.0.0"
   },
   "peerDependencies": {
-    "@adobe/aio-lib-ims": "^7"
+    "@adobe/aio-lib-ims": "^7 || ^8"
   },
   "devDependencies": {
     "@adobe/eslint-config-aio-lib-config": "^4.0.0",


### PR DESCRIPTION
## Description

Update `peerDependencies` to also support `v8` of `aio-lib-ims`. I assume that if `v7` was allowed all this time and it didn't cause any issue it means that it's also compatible, so I add both with `||`