### PR TITLE
chore(deps): upgrade major dependencies and ESLint 9

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-    "extends": ["@adobe/eslint-config-aio-lib-config"]
-}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,32 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const aioLibConfig = require('@adobe/eslint-config-aio-lib-config')
+
+module.exports = [
+  ...aioLibConfig,
+  {
+    files: ['test/**/*.js'],
+    languageOptions: {
+      globals: {
+        jest: 'readonly',
+        describe: 'readonly',
+        test: 'readonly',
+        expect: 'readonly',
+        beforeEach: 'readonly',
+        afterEach: 'readonly',
+        beforeAll: 'readonly',
+        afterAll: 'readonly'
+      }
+    }
+  }
+]

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "jsonwebtoken": "^9.0.0"
   },
   "peerDependencies": {
-    "@adobe/aio-lib-ims": "^7"
+    "@adobe/aio-lib-ims": "^8"
   },
   "devDependencies": {
     "@adobe/eslint-config-aio-lib-config": "^4.0.0",
@@ -22,11 +22,11 @@
     "eslint-plugin-n": "^15.7.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^6.6.0",
-    "globby": "^14.0.2",
-    "jest": "^29",
-    "jest-junit": "^16.0.0",
+    "globby": "^16.0.0",
+    "jest": "^30",
+    "jest-junit": "^17.0.0",
     "stdout-stderr": "^0.1.9",
-    "typescript": "^5.1.6"
+    "typescript": "^6.0.0"
   },
   "engines": {
     "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -13,18 +13,13 @@
     "@adobe/aio-lib-ims": "^8"
   },
   "devDependencies": {
-    "@adobe/eslint-config-aio-lib-config": "^4.0.0",
-    "eslint": "^8.57.1",
-    "eslint-config-standard": "^17.1.0",
-    "eslint-plugin-import": "^2.31.0",
-    "eslint-plugin-jest": "^27.9.0",
+    "@adobe/eslint-config-aio-lib-config": "^5.0.0",
+    "eslint": "^9.0.0",
     "eslint-plugin-jsdoc": "^48.11.0",
-    "eslint-plugin-n": "^15.7.0",
-    "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-promise": "^6.6.0",
     "globby": "^16.0.0",
     "jest": "^30",
     "jest-junit": "^17.0.0",
+    "neostandard": "^0",
     "stdout-stderr": "^0.1.9",
     "typescript": "^6.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "jsonwebtoken": "^9.0.0"
   },
   "peerDependencies": {
-    "@adobe/aio-lib-ims": "^8"
+    "@adobe/aio-lib-ims": "^8.1.2"
   },
   "devDependencies": {
     "@adobe/eslint-config-aio-lib-config": "^5.0.0",


### PR DESCRIPTION
## 🔗 Related PR: https://github.com/adobe/aio-lib-ims/pull/174

**The remaining uuid vulnerability will be resolved once the above PR is merged and a new version of @adobe/aio-lib-ims is published.**

---

## Summary

This PR upgrades all major dependencies to their latest compatible versions and migrates to ESLint 9 with flat config format.

### Commit 1: Upgrade major dependencies
- jest: 29 → 30
- jest-junit: 16 → 17 (fixes uuid security vulnerability)
- typescript: 5 → 6
- globby: 14 → 16
- @adobe/aio-lib-ims (peer): 7 → 8

### Commit 2: Upgrade to ESLint 9 with flat config
- eslint: 8.57.1 → 9.39.4 (latest v9)
- @adobe/eslint-config-aio-lib-config: 4.0.0 → 5.0.0
- Added: neostandard (replaces 6 eslint plugins)
- Removed: eslint-config-standard, eslint-plugin-{import,jest,n,node,promise}
- Migrated: .eslintrc.json → eslint.config.js (flat config format)

## Test Plan
- [x] All unit tests pass with 100% coverage
- [x] Linting passes with new ESLint 9 flat config
- [x] No breaking changes detected

## Security Impact
- **Before**: 6 moderate vulnerabilities
- **After**: 5 moderate vulnerabilities
- **Fixed**: 1 vulnerability (uuid in jest-junit dev dependency)
- **Remaining**: 5 vulnerabilities in @adobe/aio-lib-ims@8 dependency tree

### Note on Remaining uuid Vulnerability
The remaining 5 vulnerabilities are all the same issue:
- **Issue**: uuid < 14.0.0
- **Chain**: uuid → @azure/cosmos → @adobe/aio-lib-state → @adobe/aio-lib-ims@8
- **Resolution**: Will be fixed when https://github.com/adobe/aio-lib-ims/pull/174 is merged and published

## Deprecation Warnings
- **Before**: 7+ warnings (eslint@8, humanwhocodes packages, rimraf, glob, inflight)
- **After**: 3 warnings (all in jest@30 transitive dependencies)
- **Improvement**: Eliminated 4+ deprecation warnings

## What Cannot Be Upgraded (Blocked)

### ESLint 10
- Blocked by: @adobe/eslint-config-aio-lib-config@5 requires eslint ^9
- Status: On latest v9 (9.39.4)

### Remaining Deprecations
All 3 warnings are transitive dependencies in jest@30:
- inflight@1.0.6, glob@7.2.3, glob@10.5.0
- Dev dependencies only, low risk
- Require upstream Jest/babel-plugin-istanbul updates

## Files Changed
- `package.json` - dependency updates
- `eslint.config.js` - new flat config (added)
- `.eslintrc.json` - old config (removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)